### PR TITLE
Update ipa.go

### DIFF
--- a/ipa.go
+++ b/ipa.go
@@ -106,7 +106,7 @@ func init() {
 	// Load default IPA host
 	cfg, err := ini.Load("/etc/ipa/default.conf")
 	if err == nil {
-		ipaDefaultHost = cfg.Section("global").Key("server").MustString("localhost")
+		ipaDefaultHost = cfg.Section("global").Key("host").MustString("localhost")
 		ipaDefaultRealm = cfg.Section("global").Key("realm").MustString("LOCAL")
 	}
 }


### PR DESCRIPTION
Using 'host' instead 'server' to take ipa - hostname from /etc/ipa/default.conf
Because, server <hostname> Specifies the IPA Server hostname. This option is deprecated.