### PR TITLE
Fix OTPToken.Enabled

### DIFF
--- a/otp.go
+++ b/otp.go
@@ -75,7 +75,7 @@ func (t *OTPToken) fromJSON(raw []byte) error {
 	t.TimeStep = int(res.Get("ipatokentotptimestep.0").Int())
 	t.ClockOffest = int(res.Get("ipatokentotpclockoffset.0").Int())
 	t.ManagedBy = res.Get("managedby_user.0").String()
-	t.Enabled = "TRUE" != res.Get("ipatokendisabled.0").String()
+	t.Enabled = !res.Get("ipatokendisabled.0").Bool()
 	t.Type = res.Get("type").String()
 	t.URI = res.Get("uri").String()
 	t.Description = res.Get("description.0").String()


### PR DESCRIPTION
Fix setting of OTPToken.Enabled from "ipatokendisabled.0" which is returned as a bool converted to "true" / "false" (lower case) as a string by gjson but compared to "TRUE" (upper case).

This didn't work with current versions of gjson-v1.14.3 and FreeIPA-4.10.1, affecting Mokey (self service addon).