### PR TITLE
Implement group_add_member.

### DIFF
--- a/group.go
+++ b/group.go
@@ -1,0 +1,25 @@
+package ipa
+
+import "context"
+
+// https://freeipa.readthedocs.io/en/latest/api/group_add_member.html
+// https://github.com/freeipa/freeipa/blob/c40ce0e1ff01cbecf2d83377f48c0ace55fd1ed9/ipaserver/plugins/group.py#L633
+func (c *Client) GroupAddMember(ctx context.Context, gid string, memberId string, memberType string) (*Response, error) {
+	options := map[string]any{}
+
+	switch memberType {
+	case "user":
+		options["user"] = memberId
+	case "group":
+		options["group"] = memberId
+	case "service":
+		options["service"] = memberId
+	}
+
+	res, err := c.rpcContext(ctx, "group_add_member", []string{gid}, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
Hello,
i'm currently implementing my first "group" call I need,

First, I copied the `rpc` function and create `rpcContext` which is an exact copy but instead taking a context and use it while creating the `http.Request` struct.

For the group_add_member call itself It's very simple but I want to know your opinion about if you prefer this kind of generic function or if we create a private function like `groupAddMember` and create different functios abstracting the memberType like `GroupAddUser` `GroupAddGroup` and so on. 

Oh and I also change every call to ioutil to the os package since ioutil is deprecated now !